### PR TITLE
Add build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ data/DATA012
 data/DATA0123
 data/DATA01234
 .idea/discord.xml
+build/artifacts/*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     A simple and lightweight encrypted password manager written in Go.
     <br />
     <br />
-    <a href="https://github.com/Gyro7/Osiris-pwm/issues">Report Bug</a> || 
+    <a href="https://github.com/Gyro7/Osiris-pwm/issues">Report Bug</a> ||
     <a href="https://github.com/Gyro7/Osiris-pwm/pulls">Request Feature</a>
   </p>
 </p>
@@ -95,8 +95,7 @@ chmod +x Osiris-pwm
 ./Osiris-pwm
 ```
 #### Any other Linux distribution (Build from source)
-For this method you need to have Go installed, build-essential and a few dependencies (even tho they should be downloaded automatically)  
-If you encounter any problems in installing dependencies, follow this guide: https://github.com/go-gl/glfw
+For this method you need to have Go installed
 ```sh
 # clone and go into repo
 git clone https://github.com/Gyro7/Osiris-pwm.git
@@ -121,6 +120,41 @@ To add a new element to the grid click the white add button on the middle left.
 To delete an element, edit it so that all its entries are empty, then head to the Edit menu and click "Delete empties"
 To change theme go to File -> Settings
 
+<!-- Developing -->
+
+## Developing
+
+### Building
+
+#### Build Script
+
+A build script is provided for easy building on Linux. Docker is the only dependency.
+Using Docker allows you to build the package without installing the build chain to your
+workstation.
+```
+build/docker/build.sh
+```
+
+Built artifacts will be in `build/artifacts/` when the build is complete
+```
+ls build/artifacts
+
+Osiris-pwm  
+Osiris-pwm_linux_amd64.zip  
+Osiris-pwm.SHA256SUMS
+```
+
+#### Local build tools
+
+If Docker is not an option, or you prefer to build in your own environment, you will
+need the following installed:
+- [Go toolchain](https://golang.org/dl/)
+- A C compiler (GCC), this project uses [CGO](https://golang.org/doc/install/gccgo)
+  - Debian: build-essential
+  - Fedora: @development-tools
+- This project uses [go-gl](https://github.com/go-gl/glfw), which has its own build requirements
+
+## Roadmap
 
 <!-- ROADMAP -->
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ need the following installed:
   - Fedora: @development-tools
 - This project uses [go-gl](https://github.com/go-gl/glfw), which has its own build requirements
 
-## Roadmap
-
 <!-- ROADMAP -->
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ To change theme go to File -> Settings
 #### Build Script
 
 A build script is provided for easy building on Linux. Docker is the only dependency.
-Using Docker allows you to build the package without installing the build chain to your
-workstation.
+
+Using Docker has the following benefits:
+- Build Linux packages on Mac and Windows
+- Builds are consistent, always built the same way
+- Does not require the build chain to be installed on your workstation
+
 ```
 build/docker/build.sh
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ chmod +x Osiris-pwm
 ./Osiris-pwm
 ```
 #### Any other Linux distribution (Build from source)
-For this method you need to have Go installed
+For this method you need to have Go installed, build-essential and a few dependencies (even tho they should be downloaded automatically)  
+If you encounter any problems in installing dependencies, follow this guide: https://github.com/go-gl/glfw
 ```sh
 # clone and go into repo
 git clone https://github.com/Gyro7/Osiris-pwm.git

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ To change theme go to File -> Settings
 
 #### Build Script
 
-A build script is provided for easy building on Linux. Docker is the only dependency.
+A build script is provided for easy building. Docker is the only dependency.
 
 Using Docker has the following benefits:
 - Build Linux packages on Mac and Windows

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,3 +1,6 @@
+# This Dockerfile provides a build environment only,
+# it is not intended to be used for running Osiris-pwm.
+# See "build/docker/build.sh" for an example.
 FROM golang:1.15
 
 COPY . /app
@@ -11,7 +14,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install \
 RUN rm -f build/artifacts/* || mkdir -p build/artifacts/
 
 # cgo is required, and explicitly enabled here
-RUN CGO_ENABLED=1 go build -o build/artifacts/Osiris-pwm 
+RUN CGO_ENABLED=1 go build -o build/artifacts/Osiris-pwm
 
 # zip built binary and get the checksums
 WORKDIR /app/build/artifacts

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.15
+
+COPY . /app
+WORKDIR /app
+RUN apt-get -qq update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq install \
+  -y gcc libgl1-mesa-dev xorg-dev zip >> /dev/null
+
+# build will output to artifacts directory which may
+# or may not exist. if exists, clean it out
+RUN rm -f build/artifacts/* || mkdir -p build/artifacts/
+
+# cgo is required, and explicitly enabled here
+RUN CGO_ENABLED=1 go build -o build/artifacts/Osiris-pwm 
+
+# zip built binary and get the checksums
+WORKDIR /app/build/artifacts
+RUN zip Osiris-pwm_linux_amd64.zip Osiris-pwm
+RUN sha256sum Osiris-pwm_linux_amd64.zip > Osiris-pwm.SHA256SUMS
+RUN sha256sum Osiris-pwm >> Osiris-pwm.SHA256SUMS

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -12,8 +12,8 @@ IMAGE_TAG="${IMAGE}:${TAG}"
 CONTAINER_NAME="${IMAGE}-${TAG}"
 
 clean () {
-	docker rm -f $CONTAINER_NAME && echo "cleaned up container ${CONTAINER_NAME}"
-	docker rmi -f $IMAGE_TAG && echo "cleaned up image ${IMAGE_TAG}"
+	docker rm -f "${CONTAINER_NAME}" && echo "cleaned up container ${CONTAINER_NAME}"
+	docker rmi -f "${IMAGE_TAG}" && echo "cleaned up image ${IMAGE_TAG}"
 }
 trap clean ERR
 
@@ -23,8 +23,8 @@ build () {
 		-t "${IMAGE_TAG}" \
        		-f build/docker/Dockerfile .
 
-	docker create -ti --name $CONTAINER_NAME $IMAGE_TAG bash
-	docker cp $CONTAINER_NAME:/app/build/artifacts/. build/artifacts/
+	docker create -ti --name "${CONTAINER_NAME}" "${IMAGE_TAG}" bash
+	docker cp "${CONTAINER_NAME}:/app/build/artifacts/." build/artifacts/
 }
 
 build

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -eE  # same as: `set -o errexit -o errtrace`
+
+# cd to repo root
+cd "$(dirname "$0")"
+cd ../../
+
+IMAGE="osiris-pwm"
+TAG="build-$(date +'%s')"
+IMAGE_TAG="${IMAGE}:${TAG}"
+CONTAINER_NAME="${IMAGE}-${TAG}"
+
+clean () {
+	docker rm -f $CONTAINER_NAME && echo "cleaned up container ${CONTAINER_NAME}"
+	docker rmi -f $IMAGE_TAG && echo "cleaned up image ${IMAGE_TAG}"
+}
+trap clean ERR
+
+build () {
+	docker build \
+		--no-cache \
+		-t "${IMAGE_TAG}" \
+       		-f build/docker/Dockerfile .
+
+	docker create -ti --name $CONTAINER_NAME $IMAGE_TAG bash
+	docker cp $CONTAINER_NAME:/app/build/artifacts/. build/artifacts/
+}
+
+build
+clean


### PR DESCRIPTION
I initially had trouble building this package on my machine. I wrote a build script that leverages [Docker](https://www.docker.com/) as a build environment. 

Usage (build and run)
1. build: `build/docker/build.sh`
2. run: `build/artifacts/Osiris-pwm`

The script will cleanup containers and images, leaving behind only the built binary, zipped binary, and checksum file.

This script **should** be usable on Macos, as long as Docker is installed. Of course, the built binary will be for Linux but it gives flexibility on where Osiris-pwm can be developed.

I noticed you are building `deb` packages, `build/docker/Dockerfile` could be extended to build a `deb` package. I am happy to add that functionality, but I need the steps required for building the deb package.

I think this script will help keep builds consistent, and easy for contributors to jump right in. 